### PR TITLE
Fix markdown format in wasm demo

### DIFF
--- a/istio-weekly/007/demo.md
+++ b/istio-weekly/007/demo.md
@@ -445,13 +445,13 @@ tinygo build -o main.wasm -scheduler=none -target=wasi main.go
 
 And then re-run the Envoy proxy. Make a couple of requests like this:
 
-"`sh
+```sh
 curl -H "hello: something" localhost:10000
 ```
 
 You'll notice the log Envoy log entry like this one:
 
-"`text
+```text
 wasm log: hello_header_counter incremented
 ```
 


### PR DESCRIPTION
This patch fixes the markdown format in https://github.com/tetratelabs/istio-weekly/blob/main/istio-weekly/007/demo.md.