### PR TITLE
Configuration update

### DIFF
--- a/istio-weekly/006/config.yaml
+++ b/istio-weekly/006/config.yaml
@@ -17,6 +17,8 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
             virtual_hosts:
             - name: all_domains

--- a/istio-weekly/006/demo.md
+++ b/istio-weekly/006/demo.md
@@ -54,6 +54,8 @@ Let's update this config and add the HTTP filter and the router filter to the HT
           stat_prefix: edge
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config: {}
 ```
 


### PR DESCRIPTION
It looks like the configuration has changed when using `envoy.filters.http.router`.

- [x] Amend example config.yaml
- [x] Amend demo.md

Updated configuration as per recommendation: https://github.com/envoyproxy/envoy/issues/21464#issuecomment-1139540234

```
         - name: envoy.filters.http.router
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
```